### PR TITLE
fix that postman socket hang up when resource does not exist

### DIFF
--- a/srcs/request_handling/FixedResponses.cpp
+++ b/srcs/request_handling/FixedResponses.cpp
@@ -42,8 +42,11 @@ std::shared_ptr<ResponsePacket> no_content()
 
 std::shared_ptr<ResponsePacket> redirect(const std::string &location)
 {
-	auto response_packet = build_fixed_response(301, "Moved Permanently");
+	auto response_packet = std::make_shared<ResponsePacket>();
+	response_packet->set_status_code(301);
+	response_packet->set_status_message("Moved Permanently");
 	response_packet->setHeader("Location", location);
+	response_packet->setResponseReady(true);
 	return response_packet;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the redirect functionality for more accurate response handling, ensuring users receive the correct status message and code for permanent moves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->